### PR TITLE
Adding sendMessage and getWebsocket methods to RTM client

### DIFF
--- a/src/main/java/allbegray/slack/rtm/SlackRealTimeMessagingClient.java
+++ b/src/main/java/allbegray/slack/rtm/SlackRealTimeMessagingClient.java
@@ -203,5 +203,21 @@ public class SlackRealTimeMessagingClient {
 		});
 		thread.start();
 	}
+	
+	/**
+	 * This method sends message to slack using webSocket client
+	 * @param message
+	 */
+	public void sendMessage(String message){
+		webSocket.sendMessage(message);		
+	}
+	
+	/**
+	 * This method returns the webSocket connected with Slack RTM
+	 * @return the webSocket client object
+	 */
+	public WebSocket getWebsocket(){
+		return webSocket;
+	}
 
 }


### PR DESCRIPTION
Hi, 

1) Reason for adding sendMessage method- Today, I don't see a way to reply back slack (bot) using webSocket if you're connected using Slack RTM api, because of this, as a workaround i'm creating a SlackWebApiClient and using postMessage web api to send messages to Slack. So using the new sendMessage method I can avoid going for workaround and stick to RTM api alone.

2) Reason for adding getWebsocket method: I'm making the webSocket visible outside of SlackRealTimeMessagingClient, just to make use of the webSocket and others method provided by it apart from sendMessage.

Please go through the pull request and let me know if i'm missing something...Cheers!!