### PR TITLE
Configurable web API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ public interface SlackWebApiClient {
 	// auth
 
 	Authentication auth();
+	
+	void setWebApiUrl(String webApiUrl);
+    
+    String getWebApiUrl();
 
 	// bots
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
 			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-standalone</artifactId>
+			<version>2.6.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -49,6 +55,7 @@
 				<configuration>
 					<excludes>
 						<exclude>**/Slack*ClientTest.java</exclude>
+						<exclude>**/Slack*ClientIntegrationTest.java</exclude>
 					</excludes>
 				</configuration>
 			</plugin>

--- a/src/main/java/allbegray/slack/webapi/SlackWebApiClient.java
+++ b/src/main/java/allbegray/slack/webapi/SlackWebApiClient.java
@@ -40,6 +40,10 @@ public interface SlackWebApiClient extends
 
     void shutdown();
 
+    void setWebApiUrl(String webApiUrl);
+
+    String getWebApiUrl();
+
     Authentication auth();
 
     Bot getBotInfo(String bot);

--- a/src/main/java/allbegray/slack/webapi/SlackWebApiClientImpl.java
+++ b/src/main/java/allbegray/slack/webapi/SlackWebApiClientImpl.java
@@ -64,6 +64,7 @@ public class SlackWebApiClientImpl implements SlackWebApiClient {
 	private String token;
 	private ObjectMapper mapper;
 	private CloseableHttpClient httpClient;
+	private String webApiUrl = SlackWebApiConstants.SLACK_WEB_API_URL;
 
 	public SlackWebApiClientImpl(String token) {
 		this(token, null);
@@ -77,6 +78,16 @@ public class SlackWebApiClientImpl implements SlackWebApiClient {
 		this.token = token;
 		this.mapper = mapper != null ? mapper : new ObjectMapper();
 		httpClient = RestUtils.createHttpClient(timeout);
+	}
+
+	@Override
+	public void setWebApiUrl(String webApiUrl) {
+		this.webApiUrl = webApiUrl;
+	}
+
+	@Override
+	public String getWebApiUrl() {
+		return webApiUrl;
 	}
 
 	@Override
@@ -1227,7 +1238,7 @@ public class SlackWebApiClientImpl implements SlackWebApiClient {
 			parameters.put("token", token);
 		}
 
-		String apiUrl = SlackWebApiConstants.SLACK_WEB_API_URL + "/" + method.getMethodName();
+		String apiUrl = webApiUrl + "/" + method.getMethodName();
 
 		HttpEntity httpEntity = null;
 		if (is == null) {

--- a/src/test/java/allbegray/slack/SlackWebApiClientIntegrationTest.java
+++ b/src/test/java/allbegray/slack/SlackWebApiClientIntegrationTest.java
@@ -1,0 +1,94 @@
+package allbegray.slack;
+
+import allbegray.slack.exception.SlackResponseErrorException;
+import allbegray.slack.type.Authentication;
+import allbegray.slack.webapi.SlackWebApiClient;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.junit.*;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+public class SlackWebApiClientIntegrationTest {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule();
+    private static final String TEST_TOKEN = "testtoken";
+    private SlackWebApiClient slackWebApiClient;
+
+    @Before
+    public void setUp() {
+        slackWebApiClient = SlackClientFactory.createWebApiClient(TEST_TOKEN);
+    }
+
+    @After
+    public void tearDown() {
+        slackWebApiClient.shutdown();
+    }
+
+    @Test
+    public void testWireMock() throws IOException {
+
+        stubFor(get(urlPathEqualTo("/auth.test")).willReturn(aResponse().withBody("hello world")));
+
+        HttpGet get = new HttpGet("http://localhost:8080/auth.test");
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+        CloseableHttpResponse response = httpclient.execute(get);
+        try {
+            System.out.println("***** " + response.getStatusLine().getStatusCode());
+            System.out.println("***** " + EntityUtils.toString(response.getEntity()));
+        } finally {
+            response.close();
+        }
+
+    }
+
+    @Test
+    public void shouldAuthenticateWithATestTokenAgainstTheMockApi() {
+
+        stubFor(post(urlPathEqualTo("/auth.test"))
+                .withRequestBody(equalTo("token=" + TEST_TOKEN))
+                .willReturn(aResponse().withStatus(200)
+                        .withBody("{" +
+                                "  \"ok\": true," +
+                                "  \"url\": \"https:\\/\\/myteam.slack.com\\/\"," +
+                                "  \"team\": \"My Team\"," +
+                                "  \"user\": \"Me\"," +
+                                "  \"team_id\": \"T12345\"," +
+                                "  \"user_id\": \"U12345\"" +
+                                "}")));
+
+        slackWebApiClient.setWebApiUrl("http://localhost:8080");
+
+        Authentication auth = slackWebApiClient.auth();
+
+        Assert.assertEquals("T12345", auth.getTeam_id());
+        Assert.assertEquals("U12345", auth.getUser_id());
+        Assert.assertEquals("Me", auth.getUser());
+        Assert.assertEquals("My Team", auth.getTeam());
+        Assert.assertEquals("https://myteam.slack.com/", auth.getUrl());
+
+    }
+
+    @Test(expected = SlackResponseErrorException.class)
+    public void shouldNotAuthenticateWithATestTokenAgainstTheDefaultApi() {
+
+        try {
+            slackWebApiClient.auth();
+        }
+        catch (SlackResponseErrorException e) {
+
+            Assert.assertTrue(e.getMessage().contains("invalid_auth"));
+            throw e;
+
+        }
+
+    }
+
+}

--- a/src/test/java/allbegray/slack/SlackWebApiClientTest.java
+++ b/src/test/java/allbegray/slack/SlackWebApiClientTest.java
@@ -200,4 +200,15 @@ public class SlackWebApiClientTest {
 		Assert.assertTrue(message.getTs() != null);
 	}
 
+	@Test
+	public void shouldReturnTheDefaultApiUrlIfNotExplicitlySet() {
+		Assert.assertEquals("https://slack.com/api", webApiClient.getWebApiUrl());
+	}
+
+	@Test
+	public void shouldReturnNonDefaultApiUrlIfExplicitlySet() {
+		webApiClient.setWebApiUrl("http://localhost:8080");
+		Assert.assertEquals("http://localhost:8080", webApiClient.getWebApiUrl());
+	}
+
 }


### PR DESCRIPTION
The default web API URL can now be overridden using the appropriate setter method on the client class.

This can be especially useful for standalone integration testing where you may have a mock API service to communicate with.  An example of this can be seen in the new SlackWebApiClientIntegrationTest which has been added.