### PR TITLE
add threads support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+jdk:
+  - oraclejdk8

--- a/src/main/java/allbegray/slack/type/Message.java
+++ b/src/main/java/allbegray/slack/type/Message.java
@@ -12,6 +12,7 @@ public class Message {
 	protected String ts;
 	protected String user;
 	protected String text;
+	protected String thread_ts;
 
 	protected Boolean is_starred;
 	protected String subtype;
@@ -50,6 +51,14 @@ public class Message {
 
 	public void setText(String text) {
 		this.text = text;
+	}
+
+	public String getThread_ts() {
+		return thread_ts;
+	}
+
+	public void setThread_ts(String thread_ts) {
+		this.thread_ts = thread_ts;
 	}
 
 	public String getPermalink() {

--- a/src/main/java/allbegray/slack/webapi/method/chats/ChatPostMessageMethod.java
+++ b/src/main/java/allbegray/slack/webapi/method/chats/ChatPostMessageMethod.java
@@ -41,6 +41,7 @@ public class ChatPostMessageMethod extends AbstractMethod {
 	protected boolean unfurl_media;
 	protected String icon_url;
 	protected String icon_emoji;
+	protected String thread_ts;
 
 	public String getChannel() {
 		return channel;
@@ -125,6 +126,13 @@ public class ChatPostMessageMethod extends AbstractMethod {
 		this.icon_emoji = icon_emoji;
 	}
 
+	public String getThread_ts() {
+		return thread_ts;
+	}
+
+	public void setThread_ts(String thread_ts) {
+		this.thread_ts = thread_ts;
+	}
 	@Override
 	public String getMethodName() {
 		return SlackWebApiConstants.CHAT_POST_MESSAGE;
@@ -166,6 +174,9 @@ public class ChatPostMessageMethod extends AbstractMethod {
 		parameters.put("unfurl_media", String.valueOf(unfurl_media));
 		parameters.put("icon_url", icon_url);
 		parameters.put("icon_emoji", icon_emoji);
+		if (thread_ts != null) {
+			parameters.put("thread_ts", thread_ts);
+		}
 	}
 
 }


### PR DESCRIPTION
Added basic threads support according to https://api.slack.com/docs/message-threading
SlackWebApiClientTest is improved (random channel names are used to allow several run of test)
Also fixed test, since warning message was changed 