### PR TITLE
Don't check webhookUrl

### DIFF
--- a/src/main/java/allbegray/slack/webhook/SlackWebhookClient.java
+++ b/src/main/java/allbegray/slack/webhook/SlackWebhookClient.java
@@ -42,9 +42,6 @@ public class SlackWebhookClient {
 	public SlackWebhookClient(String webhookUrl, ObjectMapper mapper, int timeout, ProxyServerInfo proxyServerInfo) {
 		if (webhookUrl == null) {
 			throw new SlackArgumentException("Missing WebHook URL Configuration @ SlackApi");
-
-		} else if (!webhookUrl.startsWith("https://hooks.slack.com/services/")) {
-			throw new SlackArgumentException("Invalid Service URL. WebHook URL Format: https://hooks.slack.com/services/{id_1}/{id_2}/{token}");
 		}
 
 		this.webhookUrl = webhookUrl;


### PR DESCRIPTION
Please don't check the webhookUrl. I would like to use the slack-api library with the Slack compatible  software Rocketchat installed in an internal enterprise server.
Without the condition in constructor, all works fine !