### PR TITLE
add specific exception if hitting rate limits

### DIFF
--- a/src/main/java/allbegray/slack/exception/SlackResponseRateLimitException.java
+++ b/src/main/java/allbegray/slack/exception/SlackResponseRateLimitException.java
@@ -1,0 +1,15 @@
+package allbegray.slack.exception;
+
+public class SlackResponseRateLimitException extends SlackResponseErrorException {
+    private static final Long DEFAULT_RETRY_AFTER = 60L;
+
+    private Long retryAfter = DEFAULT_RETRY_AFTER;
+
+    public SlackResponseRateLimitException(Long retryAfter) {
+        this.retryAfter = retryAfter;
+    }
+
+    public Long getRetryAfter() {
+        return this.retryAfter;
+    }
+}


### PR DESCRIPTION
```SlackResponseRateLimitException```, with ```getRetryAfter()``` method in order to know waiting time.