### PR TITLE
fix dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Step 2. Add the dependency in the form
 <dependency>
     <groupId>com.github.allbegray</groupId>
     <artifactId>slack-api</artifactId>
-    <version>v1.7.0.RELEASE</version>
+    <version>1.7.0.RELEASE</version>
 </dependency>
 ```
 


### PR DESCRIPTION
I noticed the wrong version number in the README. The alternative would be to rename the release I guess.